### PR TITLE
remove default since inputs are not available at that point

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,6 @@ inputs:
   image-name:
     description: "The name of the docker image to build"
     required: false
-    default: ${{ github.repository }}-${{ inputs.caprover-app-name }}
   branch-name:
     description: "The name of the branch to deploy"
     required: false
@@ -47,8 +46,12 @@ runs:
     - name: Set the slugified image name in env
       shell: bash
       env:
-        IMAGE_NAME: ${{ inputs.image_name }}
-      run: echo "IMAGE_NAME_SLUG=$(echo $IMAGE_NAME | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)" >> $GITHUB_ENV
+        IMAGE_NAME: ${{ inputs.image-name }}
+      run: |
+        if [ -z $IMAGE_NAME ]; then
+          IMAGE_NAME=${{ github.repository }}
+        fi
+        echo "IMAGE_NAME_SLUG=$(echo $IMAGE_NAME | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr A-Z a-z)" >> $GITHUB_ENV
 
     - name: Checkout repository
       uses: actions/checkout@v4.1.1


### PR DESCRIPTION
I remove the caprover app name from the image name because github.repository already includes the GitHub username and the name of the repository itself. Adding the CapRover app name might be redundant, since it is likely to be the same as the repository name, which I assume would be the case for most people.

I'm testing this on my fork and it should work, the image is build successfully but it fails with error message

```shell
#30 ERROR: failed to push ghcr.io/tobi-de-bookworm:main: unexpected status from HEAD request to https://ghcr.io/v2/tobi-de-bookworm/blobs/sha256:f32443ed491f27eb48420b119dc7a9f225e6f2e753ea5af3d8a27561a65a35b0: 400 Bad Request
```

I don't think the issue if from this action.
Can you test it on your end to see how it goes ? you don't have to create a new release to test the action, you can just target the `main` branch instead of release tag